### PR TITLE
fix in detect stop points when none detected

### DIFF
--- a/components/stopdetector/test/fixtures/3.json
+++ b/components/stopdetector/test/fixtures/3.json
@@ -1,0 +1,3 @@
+{
+  "output_table": []
+}

--- a/components/stopdetector/test/test.json
+++ b/components/stopdetector/test/test.json
@@ -22,5 +22,17 @@
             "min_duration": 30,
             "duration_unit": "Seconds"
         }
+    },
+    {
+        "id": 3,
+        "inputs": {
+            "input_table": "trajectories",
+            "traj_id_col": "traj_id",
+            "tpoints_col": "tpoints",
+            "method": "Points",
+            "max_diameter": 30,
+            "min_duration": 3000,
+            "duration_unit": "Seconds"
+        }
     }
 ]

--- a/functions/stopdetector.sql
+++ b/functions/stopdetector.sql
@@ -74,8 +74,9 @@ def main(
     result['geometry'] = result.geometry.to_wkt()
     
     # Convert timestamps to strings with timezone info to match expected format
-    result['start_time'] = result['start_time'].dt.strftime('%Y-%m-%d %H:%M:%S+00:00')
-    result['end_time'] = result['end_time'].dt.strftime('%Y-%m-%d %H:%M:%S+00:00')
+    if 'start_time' in result.columns:
+        result['start_time'] = result['start_time'].dt.strftime('%Y-%m-%d %H:%M:%S+00:00')
+        result['end_time'] = result['end_time'].dt.strftime('%Y-%m-%d %H:%M:%S+00:00')
 
     return result.to_dict(orient='records')
 $$;


### PR DESCRIPTION
An error is raised because if moving pandas (TrajectoryStopDetector.get_stop_points) does not found any stops, columns `start_time` and `end_time` are missing from the output. We need to reformat such columns only if they are present in the resulting df.