### PR TITLE
Update package versions to Snowflake channel

### DIFF
--- a/components/trajectorysplitter/metadata.json
+++ b/components/trajectorysplitter/metadata.json
@@ -35,7 +35,7 @@
             "title": "Split method",
             "description": "Method to use when splitting the trajectories",
             "type": "Selection",
-            "options": ["Stops", "Temporal", "Speed", "Observation Gap"],
+            "options": ["Stops", "Temporal", "Speed", "Observation Gap", "Angle Change", "Value Change"],
             "default": "Stops"
         },
         {

--- a/components/trajectorysplitter/src/fullrun.sql
+++ b/components/trajectorysplitter/src/fullrun.sql
@@ -57,6 +57,13 @@ $$
             ${MIN_SPEED},
             ${MIN_LENGTH}
         )`;
+    } else if (METHOD === 'Value Change') {
+        udfCall = `@@workflows_temp@@.TRAJECTORY_VALUECHANGE_SPLITTER(
+            ${TRAJ_ID_COL},
+            ${TPOINTS_COL},
+            '${VALUECHANGE_COL}',
+            ${MIN_LENGTH}
+        )`;
     } else {
         throw new Error(`Unknown method: ${METHOD}`);
     }

--- a/functions/computemetrics.sql
+++ b/functions/computemetrics.sql
@@ -21,7 +21,7 @@ CREATE OR REPLACE FUNCTION @@workflows_temp@@.TRAJECTORY_METRICS(
 RETURNS ARRAY
 LANGUAGE PYTHON
 RUNTIME_VERSION = '3.11'
-PACKAGES = ('numpy','pandas','geopandas','movingpandas','shapely')
+PACKAGES = ('numpy','pandas','geopandas>=1.0.0','movingpandas==0.22.3','shapely')
 HANDLER = 'main'
 AS
 $$

--- a/functions/computemetrics.sql
+++ b/functions/computemetrics.sql
@@ -152,23 +152,21 @@ def main(
 
     # Keep track of which columns were actually added
     added_columns = []
-    
-    # TODO: When MovingPandas version is updated, these methods may return the trajectory object
-    # instead of modifying in-place. If so, change back to: traj = traj.add_*() pattern
+
     if input_distance_bool and input_distance_column != "undefined":
-        traj.add_distance(name=input_distance_column, units=distance_units[input_distance_unit_distance])
+        traj = traj.add_distance(name=input_distance_column, units=distance_units[input_distance_unit_distance])
         added_columns.append(input_distance_column)
     if input_duration_bool and input_duration_column != "undefined":
-        traj.add_timedelta(name=input_duration_column)
+        traj = traj.add_timedelta(name=input_duration_column)
         added_columns.append(input_duration_column)
     if input_direction_bool and input_direction_column != "undefined":
-        traj.add_direction(name=input_direction_column)
+        traj = traj.add_direction(name=input_direction_column)
         added_columns.append(input_direction_column)
     if input_speed_bool and input_speed_column != "undefined":
-        traj.add_speed(name=input_speed_column, units=(distance_units[input_speed_unit_distance], time_units[input_speed_unit_time]))
+        traj = traj.add_speed(name=input_speed_column, units=(distance_units[input_speed_unit_distance], time_units[input_speed_unit_time]))
         added_columns.append(input_speed_column)
     if input_acceleration_bool and input_acceleration_column != "undefined":
-        traj.add_acceleration(name=input_acceleration_column, units=(distance_units[input_acceleration_unit_distance], time_units[input_acceleration_unit_time], time_units[input_acceleration_unit_time]))
+        traj = traj.add_acceleration(name=input_acceleration_column, units=(distance_units[input_acceleration_unit_distance], time_units[input_acceleration_unit_time], time_units[input_acceleration_unit_time]))
         added_columns.append(input_acceleration_column)
 
     result = traj.to_point_gdf().reset_index()

--- a/functions/distancefromtrajectory.sql
+++ b/functions/distancefromtrajectory.sql
@@ -8,7 +8,7 @@ CREATE OR REPLACE FUNCTION @@workflows_temp@@.DISTANCE_FROM_TRAJECTORY(
 RETURNS FLOAT
 LANGUAGE PYTHON
 RUNTIME_VERSION = '3.11'
-PACKAGES = ('numpy','pandas','geopandas','movingpandas','shapely','pyproj')
+PACKAGES = ('numpy','pandas','geopandas>=1.0.0','movingpandas==0.22.3','shapely','pyproj')
 HANDLER = 'main'
 AS $$
 import numpy as np

--- a/functions/getvaluesattimestamp.sql
+++ b/functions/getvaluesattimestamp.sql
@@ -6,7 +6,7 @@ CREATE OR REPLACE FUNCTION @@workflows_temp@@.GET_VALUES_AT_TIMESTAMP(
 RETURNS VARIANT
 LANGUAGE PYTHON
 RUNTIME_VERSION = '3.11'
-PACKAGES = ('numpy','pandas','geopandas','movingpandas','shapely')
+PACKAGES = ('numpy','pandas','geopandas>=1.0.0','movingpandas==0.22.3','shapely')
 HANDLER = 'main'
 AS $$
 import numpy as np

--- a/functions/stopdetector.sql
+++ b/functions/stopdetector.sql
@@ -9,7 +9,7 @@ CREATE OR REPLACE FUNCTION @@workflows_temp@@.TRAJECTORY_STOP_POINTS(
 RETURNS ARRAY
 LANGUAGE python
 RUNTIME_VERSION = '3.11'
-PACKAGES = ('numpy','pandas','geopandas','movingpandas','shapely')
+PACKAGES = ('numpy','pandas','geopandas>=1.0.0','movingpandas==0.22.3','shapely')
 HANDLER = 'main'
 AS
 $$
@@ -92,7 +92,7 @@ CREATE OR REPLACE FUNCTION @@workflows_temp@@.TRAJECTORY_STOP_SEGMENTS(
 RETURNS ARRAY
 LANGUAGE python
 RUNTIME_VERSION = '3.11'
-PACKAGES = ('numpy','pandas','geopandas','movingpandas','shapely')
+PACKAGES = ('numpy','pandas','geopandas>=1.0.0','movingpandas==0.22.3','shapely')
 HANDLER = 'main'
 AS
 $$

--- a/functions/trajectorycleaner.sql
+++ b/functions/trajectorycleaner.sql
@@ -8,7 +8,7 @@ CREATE OR REPLACE FUNCTION @@workflows_temp@@.TRAJECTORY_OUTLIER_CLEANER(
 RETURNS VARIANT
 LANGUAGE PYTHON
 RUNTIME_VERSION = '3.11'
-PACKAGES = ('numpy','pandas','geopandas','movingpandas','shapely')
+PACKAGES = ('numpy','pandas','geopandas>=1.0.0','movingpandas==0.22.3','shapely')
 HANDLER = 'main'
 AS $$
 from datetime import timedelta

--- a/functions/trajectoryintersection.sql
+++ b/functions/trajectoryintersection.sql
@@ -7,7 +7,7 @@ CREATE OR REPLACE FUNCTION @@workflows_temp@@.TRAJECTORY_INTERSECTION(
 RETURNS VARIANT
 LANGUAGE PYTHON
 RUNTIME_VERSION = '3.11'
-PACKAGES = ('numpy','pandas','geopandas','movingpandas','shapely')
+PACKAGES = ('numpy','pandas','geopandas>=1.0.0','movingpandas==0.22.3','shapely')
 HANDLER = 'main'
 AS $$
 import numpy as np

--- a/functions/trajectorysplitter.sql
+++ b/functions/trajectorysplitter.sql
@@ -10,7 +10,7 @@ CREATE OR REPLACE FUNCTION @@workflows_temp@@.TRAJECTORY_STOP_SPLITTER(
 RETURNS ARRAY
 LANGUAGE python
 RUNTIME_VERSION = '3.11'
-PACKAGES = ('numpy','pandas','geopandas','movingpandas','shapely')
+PACKAGES = ('numpy','pandas','geopandas>=1.0.0','movingpandas==0.22.3','shapely')
 HANDLER = 'main'
 AS
 $$
@@ -85,7 +85,7 @@ CREATE OR REPLACE FUNCTION @@workflows_temp@@.TRAJECTORY_TEMPORAL_SPLITTER(
 RETURNS ARRAY
 LANGUAGE python
 RUNTIME_VERSION = '3.11'
-PACKAGES = ('numpy','pandas','geopandas','movingpandas','shapely')
+PACKAGES = ('numpy','pandas','geopandas>=1.0.0','movingpandas==0.22.3','shapely')
 HANDLER = 'main'
 AS
 $$
@@ -150,7 +150,7 @@ CREATE OR REPLACE FUNCTION @@workflows_temp@@.TRAJECTORY_SPEED_SPLITTER(
 RETURNS ARRAY
 LANGUAGE python
 RUNTIME_VERSION = '3.11'
-PACKAGES = ('numpy','pandas','geopandas','movingpandas','shapely')
+PACKAGES = ('numpy','pandas','geopandas>=1.0.0','movingpandas==0.22.3','shapely')
 HANDLER = 'main'
 AS
 $$
@@ -227,7 +227,7 @@ CREATE OR REPLACE FUNCTION @@workflows_temp@@.TRAJECTORY_OBSERVATION_SPLITTER(
 RETURNS ARRAY
 LANGUAGE python
 RUNTIME_VERSION = '3.11'
-PACKAGES = ('numpy','pandas','geopandas','movingpandas','shapely')
+PACKAGES = ('numpy','pandas','geopandas>=1.0.0','movingpandas==0.22.3','shapely')
 HANDLER = 'main'
 AS
 $$
@@ -303,7 +303,7 @@ CREATE OR REPLACE FUNCTION @@workflows_temp@@.TRAJECTORY_VALUECHANGE_SPLITTER(
 RETURNS ARRAY
 LANGUAGE python
 RUNTIME_VERSION = '3.11'
-PACKAGES = ('numpy','pandas','geopandas','movingpandas','shapely')
+PACKAGES = ('numpy','pandas','geopandas>=1.0.0','movingpandas==0.22.3','shapely')
 HANDLER = 'main'
 AS
 $$
@@ -376,7 +376,7 @@ CREATE OR REPLACE FUNCTION @@workflows_temp@@.TRAJECTORY_ANGLECHANGE_SPLITTER(
 RETURNS ARRAY
 LANGUAGE python
 RUNTIME_VERSION = '3.11'
-PACKAGES = ('numpy','pandas','geopandas','movingpandas','shapely')
+PACKAGES = ('numpy','pandas','geopandas>=1.0.0','movingpandas==0.22.3','shapely')
 HANDLER = 'main'
 AS
 $$

--- a/functions/trajectorysplitter.sql
+++ b/functions/trajectorysplitter.sql
@@ -292,8 +292,6 @@ def main(traj_id, trajectory, min_duration, duration_unit, min_length):
 $$;
 
 -- TRAJECTORY_VALUECHANGE_SPLITTER
--- FIXME: ValueChangeSplitter is not available in the current MovingPandas version in Snowflake
--- This function will fail at runtime until MovingPandas is updated to include ValueChangeSplitter
 CREATE OR REPLACE FUNCTION @@workflows_temp@@.TRAJECTORY_VALUECHANGE_SPLITTER(
     traj_id STRING,
     trajectory ARRAY,
@@ -364,8 +362,6 @@ def main(traj_id, trajectory, valuechange_col, min_length):
 $$;
 
 -- TRAJECTORY_ANGLECHANGE_SPLITTER
--- FIXME: AngleChangeSplitter is not available in the current MovingPandas version in Snowflake
--- This function will fail at runtime until MovingPandas is updated to include AngleChangeSplitter
 CREATE OR REPLACE FUNCTION @@workflows_temp@@.TRAJECTORY_ANGLECHANGE_SPLITTER(
     traj_id STRING,
     trajectory ARRAY,


### PR DESCRIPTION
This PR syncs the package version of `movingpandas` to that of BigQuery, enabling the methods that were previously discarded because of the older version: Value Change and Angle Change in _Split Trajectories_. It also features some changes in _Compute Trajectory Metrics_ since it change behavior from one version to the next.

This PR is to be merged once the package is released (according to Oleksii Bielov, Sept 5 - 10), but before:
- [ ] Make sure the versions pinned are correct
- [ ] Capture any missing test
- [ ] Check if the results are consistent with BigQuery's